### PR TITLE
exclude github related files from export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/.travis.yml export-ignore


### PR DESCRIPTION
this will exclude dot files from github tarball export. these are not useful for end users

i would had added `_test` as well, but wasn't sure