### PR TITLE
Add config to toggle pagetools integration

### DIFF
--- a/action/rename.php
+++ b/action/rename.php
@@ -39,22 +39,17 @@ class action_plugin_move_rename extends DokuWiki_Action_Plugin {
      * @param Doku_Event $event
      */
     public function handle_pagetools(Doku_Event $event) {
-        global $conf;
         if($event->data['view'] != 'main') return;
-
-        switch($conf['template']) {
-            case 'dokuwiki':
-            case 'arago':
-            case 'bootstrap3':
-
-                $newitem = '<li class="plugin_move_page"><a href=""><span>' . $this->getLang('renamepage') . '</span></a></li>';
-                $offset = count($event->data['items']) - 1;
-                $event->data['items'] =
-                    array_slice($event->data['items'], 0, $offset, true) +
-                    array('plugin_move' => $newitem) +
-                    array_slice($event->data['items'], $offset, null, true);
-                break;
+        if (!$this->getConf('pagetools integration')) {
+            return;
         }
+
+        $newitem = '<li class="plugin_move_page"><a href=""><span>' . $this->getLang('renamepage') . '</span></a></li>';
+        $offset = count($event->data['items']) - 1;
+        $event->data['items'] =
+            array_slice($event->data['items'], 0, $offset, true) +
+            array('plugin_move' => $newitem) +
+            array_slice($event->data['items'], $offset, null, true);
     }
 
     /**

--- a/conf/default.php
+++ b/conf/default.php
@@ -4,3 +4,4 @@ $conf['allowrename'] = '@user';
 $conf['minor'] = 1;
 $conf['autoskip'] = 0;
 $conf['autorewrite'] = 1;
+$conf['pagetools integration'] = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -4,3 +4,4 @@ $meta['allowrename'] = array('string');
 $meta['minor'] = array('onoff');
 $meta['autoskip'] = array('onoff');
 $meta['autorewrite'] = array('onoff');
+$meta['pagetools integration'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -4,3 +4,4 @@ $lang['allowrename'] = 'Allow renaming of pages to these groups and users (comma
 $lang['minor']       = 'Mark link adjustments as minor? Minor changes will not be listed in RSS feeds and subscription mails.';
 $lang['autoskip']    = 'Enable automatic skipping of errors in namespace moves by default.';
 $lang['autorewrite'] = 'Enable automatic link rewriting after namespace moves by default.';
+$lang['pagetools integration'] = 'Add renaming button to pagetools';


### PR DESCRIPTION
Having a hard-coded list of templates where the integration happens is cumbersome, because it requires a pull-request for every new template. It is also somehow the wrong order, because the templates should have the option to create special handling for specific plugins, however plugins should not have special handling for specific templates.