### PR TITLE
Cosmetics: Correct copy&paste error in documemtation comments

### DIFF
--- a/MenuItem.php
+++ b/MenuItem.php
@@ -4,9 +4,9 @@ use dokuwiki\Menu\Item\AbstractItem;
 /**
  * Class MenuItem
  *
- * Implements the PDF export button for DokuWiki's menu system
+ * Implements the Rename button for DokuWiki's menu system
  *
- * @package dokuwiki\plugin\dw2pdf
+ * @package dokuwiki\plugin\move
  */
 class MenuItem extends AbstractItem {
 


### PR DESCRIPTION
A trivial commit. I was a little irritated but quickly found out that his is a copy&paste error from the [dw2pdf](https://github.com/splitbrain/dokuwiki-plugin-dw2pdf/blob/nsbutton/MenuItem.php) plugin.