### PR TITLE
Attach JS rename handler to mobile menu items.

### DIFF
--- a/MenuItem.php
+++ b/MenuItem.php
@@ -13,6 +13,8 @@ class MenuItem extends AbstractItem {
     /** @var string icon file */
     protected $svg = __DIR__ . '/images/rename.svg';
 
+    protected $type = "plugin_move_page";
+
     public function getLinkAttributes($classprefix = 'menuitem ') {
         $attr = parent::getLinkAttributes($classprefix);
         if (empty($attr['class'])) {

--- a/MenuItem.php
+++ b/MenuItem.php
@@ -13,7 +13,7 @@ class MenuItem extends AbstractItem {
     /** @var string icon file */
     protected $svg = __DIR__ . '/images/rename.svg';
 
-    protected $type = "plugin_move_page";
+    protected $type = "plugin_move";
 
     public function getLinkAttributes($classprefix = 'menuitem ') {
         $attr = parent::getLinkAttributes($classprefix);

--- a/script/rename.js
+++ b/script/rename.js
@@ -3,81 +3,125 @@
  *
  * @author Andreas Gohr <gohr@cosmocode.de>
  */
-if(JSINFO && JSINFO.move_renameokay) {
+(function () {
+    if (!JSINFO || !JSINFO.move_renameokay) return;
+
+
+    // basic dialog template
+    const $dialog = jQuery(
+        '<div>' +
+        '<form>' +
+        '<label>' + LANG.plugins.move.newname + '<br>' +
+        '<input type="text" name="id" style="width:100%">' +
+        '</label>' +
+        '</form>' +
+        '</div>'
+    );
+
+    /**
+     * Executes the renaming based on the form contents
+     * @return {boolean}
+     */
+    const renameFN = function () {
+        const newid = $dialog.find('input[name=id]').val();
+        if (!newid) return false;
+
+        // remove buttons and show throbber
+        $dialog.html(
+            '<img src="' + DOKU_BASE + 'lib/images/throbber.gif" /> ' +
+            LANG.plugins.move.inprogress
+        );
+        $dialog.dialog('option', 'buttons', []);
+
+        // post the data
+        jQuery.post(
+            DOKU_BASE + 'lib/exe/ajax.php',
+            {
+                call: 'plugin_move_rename',
+                id: JSINFO.id,
+                newid: newid
+            },
+            // redirect or display error
+            function (result) {
+                if (result.error) {
+                    $dialog.html(result.error.msg);
+                } else {
+                    window.location.href = result.redirect_url;
+                }
+            }
+        );
+
+        return false;
+    };
+
+    /**
+     * Create the actual dialog modal and show it
+     */
+    const showDialog = function () {
+        $dialog.dialog({
+            title: LANG.plugins.move.rename + ' ' + JSINFO.id,
+            width: 800,
+            height: 200,
+            dialogClass: 'plugin_move_dialog',
+            modal: true,
+            buttons: [
+                {
+                    text: LANG.plugins.move.cancel,
+                    click: function () {
+                        $dialog.dialog("close");
+                    }
+                },
+                {
+                    text: LANG.plugins.move.rename,
+                    click: renameFN
+                }
+            ],
+            // remove HTML from DOM again
+            close: function () {
+                jQuery(this).remove();
+            }
+        });
+        $dialog.find('input[name=id]').val(JSINFO.id);
+        $dialog.find('form').submit(renameFN);
+    };
+
+    /**
+     * Bind an event handler as the first handler
+     *
+     * @param {jQuery} $owner
+     * @param {string} event
+     * @param {function} handler
+     * @link https://stackoverflow.com/a/4700103
+     */
+    const bindFirst = function ($owner, event, handler) {
+        $owner.unbind(event, handler);
+        $owner.bind(event, handler);
+
+        const events = jQuery._data($owner[0])['events'][event];
+        events.unshift(events.pop());
+
+        jQuery._data($owner[0])['events'][event] = events;
+    };
+
+
+    // attach handler to menu item
     jQuery('.plugin_move_page')
         .show()
-        .click(function(e) {
+        .click(function (e) {
             e.preventDefault();
-
-            var renameFN = function () {
-                var self = this;
-                var newid = $dialog.find('input[name=id]').val();
-                if (!newid) return false;
-
-                // remove buttons and show throbber
-                $dialog.html(
-                    '<img src="'+DOKU_BASE+'lib/images/throbber.gif" /> '+
-                        LANG.plugins.move.inprogress
-                );
-                $dialog.dialog('option', 'buttons', []);
-
-                // post the data
-                jQuery.post(
-                    DOKU_BASE + 'lib/exe/ajax.php',
-                    {
-                        call: 'plugin_move_rename',
-                        id: JSINFO.id,
-                        newid: newid
-                    },
-                    // redirect or display error
-                    function (result) {
-                        if(result.error){
-                            $dialog.html(result.error.msg);
-                        } else {
-                            window.location.href = result.redirect_url;
-                        }
-                    }
-                );
-
-                return false;
-            };
-
-            // basic dialog template
-            var $dialog = jQuery(
-                '<div>' +
-                    '<form>' +
-                    '<label>' + LANG.plugins.move.newname + '<br>' +
-                    '<input type="text" name="id" style="width:100%">' +
-                    '</label>' +
-                    '</form>' +
-                    '</div>'
-            );
-            $dialog.find('input[name=id]').val(JSINFO.id);
-            $dialog.find('form').submit(renameFN);
-
-            // set up the dialog
-            $dialog.dialog({
-                title: LANG.plugins.move.rename+' '+JSINFO.id,
-                width: 800,
-                height: 180,
-                dialogClass: 'plugin_move_dialog',
-                modal: true,
-                buttons: [
-                    {
-                        text: LANG.plugins.move.cancel,
-                        click: function () {
-                            $dialog.dialog("close");
-                        }
-                    },
-                    {
-                        text: LANG.plugins.move.rename,
-                        click: renameFN
-                    }
-                ],
-                // remove HTML from DOM again
-                close: function () {
-                    jQuery(this).remove();
-                }
-            })
+            showDialog();
         });
-}
+
+    // attach handler to mobile menu entry
+    $mobileMenuOption = jQuery('form select[name=do] option[value=plugin_move_page]');
+    if ($mobileMenuOption.length === 1) {
+        bindFirst($mobileMenuOption.form().find('select[name=do]'), 'change', function (e) {
+            if (jQuery(this).val() !== 'plugin_move_page') return;
+            e.preventDefault();
+            e.stopPropagation();
+            e.stopImmediatePropagation();
+            showDialog();
+        });
+    }
+
+})();

--- a/script/rename.js
+++ b/script/rename.js
@@ -113,13 +113,15 @@
         });
 
     // attach handler to mobile menu entry
-    $mobileMenuOption = jQuery('form select[name=do] option[value=plugin_move_page]');
+    const $mobileMenuOption = jQuery('form select[name=do] option[value=plugin_move]');
     if ($mobileMenuOption.length === 1) {
         bindFirst($mobileMenuOption.form().find('select[name=do]'), 'change', function (e) {
-            if (jQuery(this).val() !== 'plugin_move_page') return;
+            const $select = jQuery(this);
+            if ($select.val() !== 'plugin_move') return;
             e.preventDefault();
             e.stopPropagation();
             e.stopImmediatePropagation();
+            $select.val('');
             showDialog();
         });
     }


### PR DESCRIPTION
When the MobileMenu is used the required handler to show the rename
dialog wasn't attached to the select resulting in an unkown action
call.

This attaches the handler and uses a jQuery specific trick to be the
first handler to be evaluated (allowing to cancel the default handler
used on the quickselect behaviour).

fixes #150
fixes #169