### PR TITLE
Fix rewriting of links to the root start page fix #213

### DIFF
--- a/_test/pagemove.test.php
+++ b/_test/pagemove.test.php
@@ -431,12 +431,13 @@ EOT;
 [[.current_ns:|..:current_ns:]]
 [[.parallel_ns:|..parallel_ns:]]
 [[.parallel_ns:|..:parallel_ns:]]
-[[:|..:..:]]
+[[..:..:|..:..:]]
 [[..:..:parent_ns:|..:..:parent_ns:]]
 [[parent_ns:new_page|parent_ns:new_page]]
 [[parent_ns/new_page|parent_ns/new_page]]
 [[/start|/start]]
 EOT;
+        // Note: ..:..: is not a great link for a page in a namespace 'parent_ns', but it is correctly resolved.
 	    $this->assertEquals($expectedContent, $newContent);
 
 	    // page is moved to same NS as backlinking page (parent_ns)

--- a/helper/handler.php
+++ b/helper/handler.php
@@ -72,7 +72,7 @@ class helper_plugin_move_handler extends DokuWiki_Plugin {
             // FIXME this simply assumes that the link pointed to :$conf['start'], but it could also point to another page
             // resolve_pageid does a lot more here, but we can't really assume this as the original pages might have been
             // deleted already
-            if(substr($old, -1) === ':') $old .= $conf['start'];
+            if(substr($old, -1) === ':' || $old === '') $old .= $conf['start'];
 
             $moves = $this->page_moves;
         } else {
@@ -132,6 +132,11 @@ class helper_plugin_move_handler extends DokuWiki_Plugin {
         $old    = $relold;
         if($type == 'page') {
             resolve_pageid($this->ns, $old, $exists);
+            // Work around bug in DokuWiki 2020-07-29 where resolve_pageid doesn't append the start page to a link to
+            // the root.
+            if ($old === '') {
+                $old = $conf['start'];
+            }
         } else {
             resolve_mediaid($this->ns, $old, $exists);
         }


### PR DESCRIPTION
Previously, we had a bug that the "start"-name was not appended to the id in this case, and we thus didn't detect that the old relative link was still valid. Further, this could have caused issues if the root start page is renamed where certain links wouldn't have been adapted.