### PR TITLE
Fix: Put move lock to lockdir

### DIFF
--- a/helper/rewrite.php
+++ b/helper/rewrite.php
@@ -154,7 +154,7 @@ class helper_plugin_move_rewrite extends DokuWiki_Plugin {
         global $PLUGIN_MOVE_WORKING;
         global $conf;
         $PLUGIN_MOVE_WORKING = $PLUGIN_MOVE_WORKING ? $PLUGIN_MOVE_WORKING + 1 : 1;
-        $lockfile = $conf['lockdir'] . self::LOCKFILENAME;
+        $lockfile = $conf['lockdir'] . '/' . self::LOCKFILENAME;
         if (!file_exists($lockfile)) {
             io_savefile($lockfile, "1\n");
         } else {

--- a/helper/rewrite.php
+++ b/helper/rewrite.php
@@ -28,7 +28,7 @@ class helper_plugin_move_rewrite extends DokuWiki_Plugin {
     /**
      * What is they filename of the lockfile
      */
-    const LOCKFILENAME = '_plugin_move.lock';
+    const LOCKFILENAME = 'plugin_move.lock';
 
     /**
      * @var string symbol to make move operations easily recognizable in change log


### PR DESCRIPTION
The `$conf['lockdir']` was incorrectly used, it didn't add path separator like rest of the dokuwiki code does:

```
./inc/pageutils.php:    return $conf['lockdir'] . '/' . md5(cleanID($id)) . '.lock';
./inc/io.php: * inside $conf['lockdir']
./inc/io.php:    $lockDir = $conf['lockdir'].'/'.md5($file);
./inc/io.php:    $lockDir = $conf['lockdir'].'/'.md5($file);
./inc/Search/Indexer.php:        $lock = $conf['lockdir'].'/_indexer.lock';
./inc/Search/Indexer.php:        @rmdir($conf['lockdir'].'/_indexer.lock');
./inc/init.php:        'lockdir'   => 'locks',
./inc/Subscriptions/BulkSubscriptionSender.php:        $lock = $conf['lockdir'] . '/_subscr_' . md5($id) . '.lock';
./inc/Subscriptions/BulkSubscriptionSender.php:        $lock = $conf['lockdir'] . '/_subscr_' . md5($id) . '.lock';
```

this resulted the lock being named `locks_plugin_move.lock` inside data dir, not inside `data/locks`.

as the lock path is changed after this, I've also renamed the lock file without underscopre.