### PR TITLE
Fix: Allow move to work if acl is disabled

### DIFF
--- a/action/rename.php
+++ b/action/rename.php
@@ -119,12 +119,14 @@ class action_plugin_move_rename extends DokuWiki_Action_Plugin {
      * @return bool
      */
     public function renameOkay($id) {
+        global $conf;
         global $ACT;
         global $USERINFO;
         if(!($ACT == 'show' || empty($ACT))) return false;
         if(!page_exists($id)) return false;
         if(auth_quickaclcheck($id) < AUTH_EDIT) return false;
         if(checklock($id) !== false || @file_exists(wikiLockFN($id))) return false;
+        if(!$conf['useacl']) return true;
         if(!isset($_SERVER['REMOTE_USER'])) return false;
         if(!auth_isMember($this->getConf('allowrename'), $_SERVER['REMOTE_USER'], (array) $USERINFO['grps'])) return false;
 


### PR DESCRIPTION
The logic was there halfway already:

```php
if(auth_quickaclcheck($id) < AUTH_EDIT) return false;
```

that returns `AUTH_UPLOAD` permission if `$conf['useacl']` is not set.

but rest of the code can be skipped as they require `REMOTE_USER` and `$USERINFO` vars which don't exist without `$conf['useacl']`.