### PR TITLE
Integrate into media manager

### DIFF
--- a/action/rename.php
+++ b/action/rename.php
@@ -35,7 +35,11 @@ class action_plugin_move_rename extends DokuWiki_Action_Plugin {
     public function handle_init() {
         global $JSINFO;
         global $INFO;
+        global $INPUT;
+        global $USERINFO;
+
         $JSINFO['move_renameokay'] = $this->renameOkay($INFO['id']);
+        $JSINFO['move_allowrename'] = auth_isMember($this->getConf('allowrename'), $INPUT->server->str('REMOTE_USER'), (array) $USERINFO['grps']);
     }
 
     /**

--- a/helper/op.php
+++ b/helper/op.php
@@ -106,6 +106,12 @@ class helper_plugin_move_op extends DokuWiki_Plugin {
             return false;
         }
 
+        // check if the file extension is unchanged
+        if (pathinfo(mediaFN($src), PATHINFO_EXTENSION) !== pathinfo(mediaFN($dst), PATHINFO_EXTENSION)) {
+            msg($this->getLang('extensionchange'), -1);
+            return false;
+        }
+
         return true;
     }
 

--- a/lang/de-informal/lang.php
+++ b/lang/de-informal/lang.php
@@ -52,6 +52,7 @@ $lang['move_media_and_pages']  = 'Seiten und Mediendateien';
 $lang['nodst']                 = 'Kein neuer Name angegeben';
 $lang['noaction']              = 'Es wurden keine Verschiebungen angegeben';
 $lang['renamepage']            = 'Seite umbenennen';
+$lang['notallowed']            = 'Du hast unzureichende Rechte, um Seiten oder Medien umzubenennen.';
 $lang['cantrename']            = 'Auf die Seite kann zur Zeit nicht zugegriffen werden - bitte versuche es später noch einmal.';
 $lang['js']['rename']          = 'Umbenennen';
 $lang['js']['cancel']          = 'Abbrechen';

--- a/lang/de-informal/lang.php
+++ b/lang/de-informal/lang.php
@@ -19,6 +19,7 @@ $lang['nomediarights']         = 'Du hast unzureichende Rechte, um die Mediendat
 $lang['medianotchanged']       = 'Kein Ziel für Seite %s angegeben (Ort bleibt unverändert).';
 $lang['mediaexists']           = 'Mediendatei %s kann nicht nach %s verschoben werden, da das Ziel bereits existiert.';
 $lang['nomediatargetperms']    = 'Du hast keine Berechtigung, die Mediendatei %s anzulegen.';
+$lang['extensionchange']       = 'Die Dateierweiterungen der alten und der neuen Datei sind unterschiedlich.';
 $lang['indexerror']            = 'Fehler während der Aktualisierung des Suchindexes %s';
 $lang['metamoveerror']         = 'Die Metadateien der Seite %s konnten nicht verschoben werden';
 $lang['atticmoveerror']        = 'Die Attic-Dateien der Seite %s konnten nicht verschoben werden. Bitte verschiebe Sie sie manuell.';

--- a/lang/de-informal/lang.php
+++ b/lang/de-informal/lang.php
@@ -65,7 +65,5 @@ $lang['noscript']              = 'Dieses Feature benötigt JavaScript.';
 $lang['moveinprogress']        = 'Eine andere Verschiebeoperation läuft momentan, du kannst dieses Tool gerade nicht benutzen.';
 
 // Media Manager
-$lang['errorOverwrite']         = 'Die Datei existiert bereits!';
-$lang['errorPermissions']       = 'Du hast unzureichende Rechte, um die Datei in den Zielnamensraum zu verschieben!';
 $lang['js']['moveButton']       = 'Datei verschieben / umbenennen';
 $lang['js']['dialogIntro']      = 'Neuer Dateiname. Du kannst den Namensraum ändern, aber nicht die Dateierweiterung.';

--- a/lang/de-informal/lang.php
+++ b/lang/de-informal/lang.php
@@ -63,3 +63,9 @@ $lang['js']['duplicate']       = 'Entschuldigung, "%s" existiert in diesem Namen
 $lang['root']                  = '[Oberster Namensraum]';
 $lang['noscript']              = 'Dieses Feature benötigt JavaScript.';
 $lang['moveinprogress']        = 'Eine andere Verschiebeoperation läuft momentan, du kannst dieses Tool gerade nicht benutzen.';
+
+// Media Manager
+$lang['errorOverwrite']         = 'Die Datei existiert bereits!';
+$lang['errorPermissions']       = 'Du hast unzureichende Rechte, um die Datei in den Zielnamensraum zu verschieben!';
+$lang['js']['moveButton']       = 'Datei verschieben / umbenennen';
+$lang['js']['dialogIntro']      = 'Neuer Dateiname. Du kannst den Namensraum ändern, aber nicht die Dateierweiterung.';

--- a/lang/de-informal/settings.php
+++ b/lang/de-informal/settings.php
@@ -5,7 +5,7 @@
  *
  * @author F. Mueller-Donath <j.felix@mueller-donath.de>
  */
-$lang['allowrename']           = 'Umbenennen von Seiten diesen Gruppen und Benutzern erlauben (durch Kommas getrennt).';
+$lang['allowrename']           = 'Umbenennen von Seiten und Mediendateien diesen Gruppen und Benutzern erlauben (durch Kommas getrennt).';
 $lang['minor']                 = 'Linkanpassung als kleine Änderung markieren? Kleine Änderungen werden in RSS Feeds und Benachrichtigungsmails nicht aufgeführt.';
 $lang['autoskip']              = 'Automatisches Überspringen von Fehlern beim Verschieben von Namensräumen standardmäßig aktivieren. ';
 $lang['autorewrite']           = 'Automatische Linkanpassung standardmäßig aktivieren.';

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -65,3 +65,9 @@ $lang['js']['duplicate']       = 'Entschuldigung, "%s" existiert in diesem Namen
 $lang['root']                  = '[Oberster Namensraum]';
 $lang['noscript']              = 'Dieses Feature benötigt JavaScript.';
 $lang['moveinprogress']        = 'Eine andere Verschiebeoperation läuft momentan, Sie können dieses Tool gerade nicht benutzen.';
+
+// Media Manager
+$lang['errorOverwrite']         = 'Die Datei existiert bereits!';
+$lang['errorPermissions']       = 'Sie haben unzureichende Rechte, um die Datei in den Zielnamensraum zu verschieben!';
+$lang['js']['moveButton']       = 'Datei verschieben / umbenennen';
+$lang['js']['dialogIntro']      = 'Neuer Dateiname. Sie können den Namensraum ändern, aber nicht die Dateierweiterung.';

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -54,6 +54,7 @@ $lang['move_media_and_pages']  = 'Seiten und Mediendateien';
 $lang['nodst']                 = 'Kein neuer Name angegeben';
 $lang['noaction']              = 'Es wurden keine Verschiebungen angegeben';
 $lang['renamepage']            = 'Seite umbenennen';
+$lang['notallowed']            = 'Sie haben unzureichende Rechte, um Seiten oder Medien umzubenennen.';
 $lang['cantrename']            = 'Auf die Seite kann zur Zeit nicht zugegriffen werden - versuchen Sie es später noch einmal.';
 $lang['js']['rename']          = 'Umbenennen';
 $lang['js']['cancel']          = 'Abbrechen';

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -67,7 +67,5 @@ $lang['noscript']              = 'Dieses Feature benötigt JavaScript.';
 $lang['moveinprogress']        = 'Eine andere Verschiebeoperation läuft momentan, Sie können dieses Tool gerade nicht benutzen.';
 
 // Media Manager
-$lang['errorOverwrite']         = 'Die Datei existiert bereits!';
-$lang['errorPermissions']       = 'Sie haben unzureichende Rechte, um die Datei in den Zielnamensraum zu verschieben!';
 $lang['js']['moveButton']       = 'Datei verschieben / umbenennen';
 $lang['js']['dialogIntro']      = 'Neuer Dateiname. Sie können den Namensraum ändern, aber nicht die Dateierweiterung.';

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -21,6 +21,7 @@ $lang['nomediarights']         = 'Sie haben unzureichende Rechte, um die Mediend
 $lang['medianotchanged']       = 'Kein Ziel für Seite %s angegeben (Ort bleibt unverändert).';
 $lang['mediaexists']           = 'Mediendatei %s kann nicht nach %s verschoben werden, da das Ziel bereits existiert.';
 $lang['nomediatargetperms']    = 'Sie haben nicht die Berechtigung, die Mediendatei %s anzulegen.';
+$lang['extensionchange']       = 'Die Dateierweiterungen der alten und der neuen Datei sind unterschiedlich.';
 $lang['indexerror']            = 'Fehler während der Aktualisierung des Suchindexes %s';
 $lang['metamoveerror']         = 'Die Metadateien der Seite %s konnten nicht verschoben werden';
 $lang['atticmoveerror']        = 'Die Attic-Dateien der Seite %s konnten nicht verschoben werden. Bitte verschieben Sie sie manuell.';

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -6,7 +6,7 @@
  * @author F. Mueller-Donath <j.felix@mueller-donath.de>
  * @author e-dschungel <github@e-dschungel.de>
  */
-$lang['allowrename']           = 'Umbenennen von Seiten diesen Gruppen und Benutzern erlauben (durch Kommas getrennt).';
+$lang['allowrename']           = 'Umbenennen von Seiten und Mediendateien diesen Gruppen und Benutzern erlauben (durch Kommas getrennt).';
 $lang['minor']                 = 'Linkanpassung als kleine Änderung markieren? Kleine Änderung werden in RSS Feeds und Benachrichtigungsmails nicht aufgeführt.';
 $lang['autoskip']              = 'Automatisches Überspringen von Fehlern beim Verschieben von Namensräumen standardmäßig aktivieren. ';
 $lang['autorewrite']           = 'Automatische Linkanpassung standardmäßig aktivieren.';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -80,3 +80,9 @@ $lang['moveinprogress']   = 'There is another move operation in progress current
 $lang['js']['renameitem'] = 'Rename this item';
 $lang['js']['add']        = 'Create a new namespace';
 $lang['js']['duplicate']  = 'Sorry, "%s" already exists in this namespace.';
+
+// Media Manager
+$lang['errorOverwrite'] = 'File already exists!';
+$lang['errorPermissions'] = 'You have no permissions to create files in the target namespace!';
+$lang['js']['moveButton'] = 'Move file';
+$lang['js']['dialogIntro'] = 'Enter new file destination. You may change the namespace but not the file extension.';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -68,6 +68,7 @@ $lang['noaction']             = 'There were no moves defined';
 // Rename feature
 $lang['renamepage']       = 'Rename Page';
 $lang['cantrename']       = 'The page can\'t be renamed right now. Please try later.';
+$lang['notallowed']       = 'You are not allowed to rename pages or media.';
 $lang['js']['rename']     = 'Rename';
 $lang['js']['cancel']     = 'Cancel';
 $lang['js']['newname']    = 'New name:';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -24,6 +24,7 @@ $lang['nomediarights']      = 'You have insufficient permissions to delete %s.';
 $lang['medianotchanged']    = 'No new destination given for page %s (location unchanged).';
 $lang['mediaexists']        = 'Media %s can\'t be moved to %s, the target already exists.';
 $lang['nomediatargetperms'] = 'You don\'t have the permission to create the media file %s.';
+$lang['extensionchange']    = 'Extension of the new file is not the same as the original.';
 
 // system errors
 $lang['indexerror']          = 'Error while updating the search index %s';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -82,7 +82,5 @@ $lang['js']['add']        = 'Create a new namespace';
 $lang['js']['duplicate']  = 'Sorry, "%s" already exists in this namespace.';
 
 // Media Manager
-$lang['errorOverwrite'] = 'File already exists!';
-$lang['errorPermissions'] = 'You have no permissions to create files in the target namespace!';
 $lang['js']['moveButton'] = 'Move file';
 $lang['js']['dialogIntro'] = 'Enter new file destination. You may change the namespace but not the file extension.';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,6 +1,6 @@
 <?php
 
-$lang['allowrename'] = 'Allow renaming of pages to these groups and users (comma separated).';
+$lang['allowrename'] = 'Allow renaming of pages and media to these groups and users (comma separated).';
 $lang['minor']       = 'Mark link adjustments as minor? Minor changes will not be listed in RSS feeds and subscription mails.';
 $lang['autoskip']    = 'Enable automatic skipping of errors in namespace moves by default.';
 $lang['autorewrite'] = 'Enable automatic link rewriting after namespace moves by default.';

--- a/lang/pl/lang.php
+++ b/lang/pl/lang.php
@@ -31,8 +31,8 @@ $lang['newname']     = 'Nowa nazwa dokumentu:';
 $lang['targetns']    = 'Nazwa docelowego katalogu:';
 $lang['submit']      = 'Zmień';
 
+$lang['extensionchange']        = 'Rozszerzenia plików nie są identyczne.';
+
 // Media Manager
-$lang['errorOverwrite']         = 'Plik już istnieje!';
-$lang['errorPermissions']       = 'Niewystarczające uprawnienia by wykonać operację!';
 $lang['js']['moveButton']       = 'Przenieś/Zmień nazwę';
 $lang['js']['dialogIntro']      = 'Nowa nazwa pliku. Możesz zmienić katalog, ale nie rozszerzenie pliku.';

--- a/lang/pl/lang.php
+++ b/lang/pl/lang.php
@@ -31,6 +31,7 @@ $lang['newname']     = 'Nowa nazwa dokumentu:';
 $lang['targetns']    = 'Nazwa docelowego katalogu:';
 $lang['submit']      = 'Zmień';
 
+$lang['notallowed']             = 'Brak uprawnień do wykonania zmiany.';
 $lang['extensionchange']        = 'Rozszerzenia plików nie są identyczne.';
 
 // Media Manager

--- a/lang/pl/lang.php
+++ b/lang/pl/lang.php
@@ -30,3 +30,9 @@ $lang['linkchange1'] = 'Linki do %s zmienione na %s';
 $lang['newname']     = 'Nowa nazwa dokumentu:';
 $lang['targetns']    = 'Nazwa docelowego katalogu:';
 $lang['submit']      = 'Zmień';
+
+// Media Manager
+$lang['errorOverwrite']         = 'Plik już istnieje!';
+$lang['errorPermissions']       = 'Niewystarczające uprawnienia by wykonać operację!';
+$lang['js']['moveButton']       = 'Przenieś/Zmień nazwę';
+$lang['js']['dialogIntro']      = 'Nowa nazwa pliku. Możesz zmienić katalog, ale nie rozszerzenie pliku.';

--- a/script.js
+++ b/script.js
@@ -5,6 +5,8 @@
  */
 
 /* DOKUWIKI:include_once script/json2.js */
+/* DOKUWIKI:include script/MoveMediaManager.js */
+
 jQuery(function() {
     /* DOKUWIKI:include script/form.js */
     /* DOKUWIKI:include script/progress.js */

--- a/script/MoveMediaManager.js
+++ b/script/MoveMediaManager.js
@@ -1,0 +1,165 @@
+/**
+ * Integrates move capability into the media manager
+ * Based on the implementation in diagrams plugin
+ */
+class MoveMediaManager {
+
+    constructor() {
+        const filePanel = document.querySelector('#mediamanager__page .panel.file');
+        if (filePanel) {
+            const observer = new MutationObserver(this.#addEditButton.bind(this));
+            observer.observe(filePanel, {childList: true, subtree: true});
+        }
+    }
+
+    /**
+     * Observer callback to add the edit button in the detail panel of the media manager
+     *
+     * @param mutationsList
+     * @param observer
+     */
+    async #addEditButton(mutationsList, observer) {
+        for (let mutation of mutationsList) {
+            // div.file has been filled with new content?
+            if (mutation.type !== 'childList') continue;
+
+            // check that the file panel contains a link to a file
+            if (mutation.target.classList.contains('file') === false) continue;
+            const link = mutation.target.querySelector('a.select.mediafile');
+            if (!link) continue;
+
+            const uri = link.getAttribute('href');
+
+            const [ , paramString ] = uri.split( '?' );
+            const searchParams = new URLSearchParams(paramString);
+            const src = searchParams.get('media');
+
+            const actionList = mutation.target.querySelector('ul.actions');
+            if (actionList.querySelector('button.move-btn')) continue; // already added
+
+
+            const moveButton = document.createElement('button');
+            moveButton.classList.add('move-btn');
+            moveButton.innerText = LANG.plugins.move.moveButton;
+
+            moveButton.addEventListener('click',  this.#showDialog.bind(this, src));
+            actionList.appendChild(moveButton);
+        }
+    }
+
+    /**
+     * Show the move dialog
+     *
+     * Uses JQuery UI
+     *
+     * @param {string} src
+     * @param {Event} event
+     * @returns {Promise<void>}
+     */
+    async #showDialog(src, event) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const $form = jQuery(this.#buildForm(src));
+        $form.dialog({
+            title: LANG.plugins.move.moveButton,
+            width: 600,
+            appendTo: '.dokuwiki',
+            modal: true,
+            close: function () {
+                // do not reuse the dialog
+                // https://stackoverflow.com/a/2864783
+                jQuery(this).dialog('destroy').remove();
+            }
+        });
+    }
+
+    /**
+     * Create the form for the old and new file names
+     *
+     * @param {string} src
+     * @returns {HTMLDivElement}
+     */
+    #buildForm(src) {
+        const wrapper = document.createElement('div');
+        const form = document.createElement('form');
+        wrapper.appendChild(form);
+
+        const intro = document.createElement('p');
+        intro.innerText = LANG.plugins.move.dialogIntro;
+        form.appendChild(intro);
+
+        const original = document.createElement('input');
+        original.type = 'hidden';
+        original.name = 'move-old-filename';
+        original.value = src;
+        form.appendChild(original);
+
+        // strip file extension and put it in a readonly field so it may not be modified
+        const fileExt = document.createElement('input');
+        fileExt.type = 'text';
+        fileExt.readOnly = true;
+        fileExt.size = 5;
+        fileExt.name = 'move-file-ext';
+        fileExt.value = src.split('.').pop();
+
+        const destination = document.createElement('input');
+        destination.type = 'text';
+        destination.className = 'edit';
+        destination.name = 'move-new-filename';
+        destination.value = src.substring(0, src.length - (fileExt.value.length + 1));
+        destination.size = 50;
+        form.appendChild(destination);
+        form.appendChild(fileExt);
+
+        const button = document.createElement('button');
+        button.innerText = LANG.plugins.move.moveButton;
+        form.appendChild(button);
+
+        form.addEventListener('submit', this.#requestMove.bind(this, form));
+
+        return wrapper;
+    }
+
+    /**
+     * Send move request to backend
+     *
+     * @param {HTMLFormElement} form
+     * @param {Event} event
+     * @returns {Promise<void>}
+     */
+    async #requestMove(form, event) {
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        const src = form.querySelector('input[name="move-old-filename"]').value;
+        const dst = form.querySelector('input[name="move-new-filename"]').value;
+        const ext = form.querySelector('input[name="move-file-ext"]').value;
+
+        jQuery.post(
+            DOKU_BASE + 'lib/exe/ajax.php',
+            {
+                call: 'plugin_move_rename_mediamanager',
+                src: src,
+                dst: dst + '.'  + ext
+            },
+            // redirect or display error
+            function (result) {
+                if (result.error) {
+                    const errorText = document.createElement('strong');
+                    errorText.innerText = result.error.join();
+                    errorText.style = 'color: red;';
+                    form.prepend(errorText);
+                } else {
+                    window.location.href = result.redirect_url;
+                }
+            }
+        );
+    }
+}
+
+// initialize
+document.addEventListener('DOMContentLoaded', () => {
+    new MoveMediaManager();
+});

--- a/script/MoveMediaManager.js
+++ b/script/MoveMediaManager.js
@@ -5,20 +5,23 @@
 class MoveMediaManager {
 
     constructor() {
+        // user is not allowed to move anything
+        if (!JSINFO.move_allowrename) return;
+
         const filePanel = document.querySelector('#mediamanager__page .panel.file');
         if (filePanel) {
-            const observer = new MutationObserver(this.#addEditButton.bind(this));
+            const observer = new MutationObserver(this.#addMoveButton.bind(this));
             observer.observe(filePanel, {childList: true, subtree: true});
         }
     }
 
     /**
-     * Observer callback to add the edit button in the detail panel of the media manager
+     * Observer callback to add the move button in the detail panel of the media manager
      *
      * @param mutationsList
      * @param observer
      */
-    async #addEditButton(mutationsList, observer) {
+    async #addMoveButton(mutationsList, observer) {
         for (let mutation of mutationsList) {
             // div.file has been filled with new content?
             if (mutation.type !== 'childList') continue;


### PR DESCRIPTION
Implements #209

A rename button is added to the file detail view in media manager. The user can enter the new destination in a popup dialog.

If the move operation does not return any errors, the media manager reloads the target namespace.

<img width="620" alt="move-mm" src="https://github.com/michitux/dokuwiki-plugin-move/assets/17853330/45e2851d-cac3-45c2-8b74-950d3b332f45">
