### PR TITLE
Fix media renaming with URL rewriting

### DIFF
--- a/script/MoveMediaManager.js
+++ b/script/MoveMediaManager.js
@@ -37,12 +37,7 @@ class MoveMediaManager {
             const deleteButton = actionList.querySelector('form#mediamanager__btn_delete');
             if (deleteButton === null) continue; // no delete permissions
 
-            const uri = link.getAttribute('href');
-
-            const [ , paramString ] = uri.split( '?' );
-            const searchParams = new URLSearchParams(paramString);
-            const src = searchParams.get('media');
-
+            const src = link.textContent;
 
             const moveButton = document.createElement('button');
             moveButton.classList.add('move-btn');


### PR DESCRIPTION
The rename button in media manager used to get the media id from link's href attribute. This did not work with URL rewriting.