### PR TITLE
Fix issue #251 and others 'undefined array key' errors.

### DIFF
--- a/action/rename.php
+++ b/action/rename.php
@@ -37,6 +37,13 @@ class action_plugin_move_rename extends DokuWiki_Action_Plugin {
         global $INFO;
         global $INPUT;
         global $USERINFO;
+        
+        if ( !isset($USERINFO['grps']) ){
+            $USERINFO['grps'] = '';
+        }
+        if ( !isset($INFO['id']) ){
+            $INFO['id'] = '';
+        }
 
         $JSINFO['move_renameokay'] = $this->renameOkay($INFO['id']);
         $JSINFO['move_allowrename'] = auth_isMember($this->getConf('allowrename'), $INPUT->server->str('REMOTE_USER'), (array) $USERINFO['grps']);
@@ -70,6 +77,9 @@ class action_plugin_move_rename extends DokuWiki_Action_Plugin {
      */
     public function addsvgbutton(Doku_Event $event) {
         global $INFO, $JSINFO;
+        if ( !isset($JSINFO['move_renameokay']) ){
+            $JSINFO['move_renameokay'] = '';
+        }
         if(
             $event->data['view'] !== 'page' ||
             !$this->getConf('pagetools_integration') ||


### PR DESCRIPTION
This is a `diff` between my changes and the file from current master branch. These lines were added. These additions are harmless to the plugin and has no reasons to not add them:
```
39a40,46
>         
>         if ( !isset($USERINFO['grps']) ){
>             $USERINFO['grps'] = '';
>         }
>         if ( !isset($INFO['id']) ){
>             $INFO['id'] = '';
>         }
72a80,82
>         if ( !isset($JSINFO['move_renameokay']) ){
>             $JSINFO['move_renameokay'] = '';
>         }
```