### PR TITLE
Fix for resolve_pageid() and resolve_mediaid() in helper/handler.php

### DIFF
--- a/helper/handler.php
+++ b/helper/handler.php
@@ -9,6 +9,9 @@
 // must be run within Dokuwiki
 if(!defined('DOKU_INC')) die();
 
+use dokuwiki\File\MediaResolver;
+use dokuwiki\File\PageResolver;
+
 /**
  * Handler class for move. It does the actual rewriting of the content.
  *
@@ -131,14 +134,28 @@ class helper_plugin_move_handler extends DokuWiki_Plugin {
         $exists = false;
         $old    = $relold;
         if($type == 'page') {
-            resolve_pageid($this->ns, $old, $exists);
+/*            resolve_pageid($this->ns, $old, $exists);
+ FIX REFERENCE GUIDE:
+ DokuWiki "Refactoring 2021"
+ https://www.dokuwiki.org/devel:releases:refactor2021?s[]=resolve&s[]=mediaid#refactoring_of_id_resolving
+*/
+            $resolver = new PageResolver($this->ns);
+            $old = $resolver->resolveId($old);
+            $exists = page_exists($old);
             // Work around bug in DokuWiki 2020-07-29 where resolve_pageid doesn't append the start page to a link to
             // the root.
             if ($old === '') {
                 $old = $conf['start'];
             }
         } else {
-            resolve_mediaid($this->ns, $old, $exists);
+/*            resolve_mediaid($this->ns, $old, $exists);
+ FIX REFERENCE GUIDE:
+ DokuWiki "Refactoring 2021"
+ https://www.dokuwiki.org/devel:releases:refactor2021?s[]=resolve&s[]=mediaid#refactoring_of_id_resolving
+*/
+            $resolver = new MediaResolver($this->ns);
+            $old = $resolver->resolveId($old);
+            $exists = media_exists($old);
         }
         if($old == $new) {
             return $relold; // old link still resolves, keep as is


### PR DESCRIPTION
Fix for `resolve_pageid()` and `resolve_mediaid()` deprecation warnings in `helper/handler.php` (lines 134 and 141) based upon [DokuWiki's Refactoring 2021](https://www.dokuwiki.org/devel:releases:refactor2021#refactoring_of_id_resolving).

I made many attempts and this seems to be the most correct, because this time I followed the instructions in the Refactoring 2021 guide mentioned above.

## Changes
Changed:
```php
resolve_pageid($this->ns, $old, $exists);
```
To:
```php
$resolver = new PageResolver($this->ns);
$old = $resolver->resolveId($old);
$exists = page_exists($old);
```
Changed:
```php
resolve_mediaid($this->ns, $old, $exists);
```
To:
```php
$resolver = new MediaResolver($this->ns);
$old = $resolver->resolveId($old);
$exists = media_exists($old);
```
## Remaing warnings
This warning seems to be similar to the ones above and is in the same file, but i don't understand ho to fix it:
```
resolve_id() is deprecated. It was called from helper_plugin_move_handler::resolveMoves() in .../lib/plugins/move/helper/handler.php:72 dokuwiki\File\Resolver and its children should be used instead!
```
The [DokuWiki's Refactoring 2021](https://www.dokuwiki.org/devel:releases:refactor2021#refactoring_of_id_resolving) tells to use PageResolver OR MediaResolver. But i don't know...

There are other 4 deprecation warnings, but not related to Resolver.

```
JSON::encode() is deprecated. It was called from action_plugin_move_rename::handle_ajax() in .../lib/plugins/move/action/rename.php:119 json_encode should be used instead!

trigger_event() is deprecated. It was called from helper_plugin_move_rewrite::rewrite() in .../lib/plugins/move/helper/rewrite.php:237 \dokuwiki\Extension\Event::createAndTrigger should be used instead!

Doku_Parser::__construct() is deprecated. It was called from helper_plugin_move_rewrite::rewrite() in .../lib/plugins/move/helper/rewrite.php:242 dokuwiki\Parsing\Parser should be used instead!

helper_plugin_move_handler::_finalize() is deprecated. It was called from dokuwiki\Parsing\Parser::parse in .../inc/Parsing/Parser.php:120 finalize() should be used instead!
```