### PR TITLE
Fix PHP warning when user not logged in

### DIFF
--- a/action/rename.php
+++ b/action/rename.php
@@ -39,7 +39,11 @@ class action_plugin_move_rename extends DokuWiki_Action_Plugin {
         global $USERINFO;
 
         $JSINFO['move_renameokay'] = $this->renameOkay($INFO['id']);
-        $JSINFO['move_allowrename'] = auth_isMember($this->getConf('allowrename'), $INPUT->server->str('REMOTE_USER'), (array) $USERINFO['grps']);
+        $JSINFO['move_allowrename'] = auth_isMember(
+            $this->getConf('allowrename'),
+            $INPUT->server->str('REMOTE_USER'),
+            $USERINFO['grps'] ?? []
+        );
     }
 
     /**

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   move
 author Michael Hamann, Gary Owen, Arno Puschmann, Christoph Jähnigen
 email  michael@content-space.de
-date   2022-01-23
+date   2024-04-26
 name   Move plugin
 desc   Move and rename pages and media files whilst maintaining the links.
-url    http://www.dokuwiki.org/plugin:move
+url    https://www.dokuwiki.org/plugin:move


### PR DESCRIPTION
Warning: Trying to access array offset on value of type null in
./dokuwiki/move/action/rename.php on line 42

$USERINFO is null when user is not logged in.

Regression introduced by 0af31bb63abd3731e904efc2ed90dd3ce33f4e52 (#246).

Fixes #256, #255
