### PR TITLE
show the actual reason when a page rename fails #324

### DIFF
--- a/action/rename.php
+++ b/action/rename.php
@@ -105,7 +105,6 @@ class action_plugin_move_rename extends DokuWiki_Action_Plugin {
         $event->preventDefault();
         $event->stopPropagation();
 
-        global $MSG;
         global $INPUT;
 
         $src = cleanID($INPUT->str('id'));
@@ -127,7 +126,7 @@ class action_plugin_move_rename extends DokuWiki_Action_Plugin {
         /** @var helper_plugin_move_plan $plan */
         $plan = plugin_load('helper', 'move_plan');
         if($plan->isCommited()) {
-            echo json_encode(['error' => $this->getLang('cantrename')]);
+            echo json_encode(['error' => $this->getLang('moveinprogress')]);
             return;
         }
         $plan->setOption('autorewrite', true);
@@ -154,20 +153,21 @@ class action_plugin_move_rename extends DokuWiki_Action_Plugin {
 
         try {
             // commit and execute the plan
-            $plan->commit();
+            if(!$plan->commit()) {
+                // a failed commit leaves its reason in the global message array
+                throw new \Exception($plan->lastMessage() ?: $this->getLang('cantrename'));
+            }
             do {
                 $next = $plan->nextStep();
-                if ($next === false) throw new \Exception('Move plan failed');
+                if ($next === false) {
+                    // storeError() has moved the reason into the plan's options and
+                    // cleared the global message array, so read the detail from there
+                    throw new \Exception($plan->getOption('lasterror') ?: $this->getLang('cantrename'));
+                }
             } while ($next > 0);
             echo json_encode(array('redirect_url' => wl($dst, '', true, '&')));
         } catch (\Exception $e) {
-            // error should be in $MSG
-            if(isset($MSG[0])) {
-                $error = $MSG[0]; // first error
-            } else {
-                $error = $this->getLang('cantrename') . ' ' . $e->getMessage();
-            }
-            echo json_encode(['error' => $error]);
+            echo json_encode(['error' => $e->getMessage()]);
         }
     }
 

--- a/helper/plan.php
+++ b/helper/plan.php
@@ -498,7 +498,8 @@ class helper_plugin_move_plan extends DokuWiki_Plugin {
 
                     // automatically skip this item only if wanted...
                     if(!$this->options['autoskip']) {
-                        // ...otherwise abort the operation
+                        // ...otherwise record the failure and abort the operation
+                        $this->write_log($log);
                         fclose($doclist);
                         $return_items_run = false;
                         break;
@@ -922,8 +923,6 @@ class helper_plugin_move_plan extends DokuWiki_Plugin {
      * @author Michael Große <grosse@cosmocode.de>
      */
     public function build_log_line ($type, $from, $to, $success) {
-        global $MSG;
-
         $now = time();
         $date   = date('Y-m-d H:i:s', $now); // for human readability
         if($success) {
@@ -931,11 +930,22 @@ class helper_plugin_move_plan extends DokuWiki_Plugin {
             $msg = '';
         } else {
             $ok  = 'failed';
-            $msg = $MSG[count($MSG) - 1]['msg']; // get detail from message array
+            $msg = $this->lastMessage(); // get detail from message array
         }
 
         $log = "$now\t$date\t$type\t$from\t$to\t$ok\t$msg\n";
         return $log;
+    }
+
+    /**
+     * Get the text of the last message in the global message array
+     *
+     * @return string the message text or an empty string if none is available
+     */
+    public function lastMessage() {
+        global $MSG;
+        $last = is_array($MSG) ? end($MSG) : false;
+        return (is_array($last) && isset($last['msg'])) ? $last['msg'] : '';
     }
 
     /**


### PR DESCRIPTION
Renaming a page always showed the generic "Move plan failed", hiding the real reason (for example that the target page already exists). storeError() had already removed the detail from the global message array before the AJAX handler read it, so the fallback message was always used. The reason is now taken from the plan's stored lasterror, and an already pending move reports a clearer message.

Failed operations are recorded in the move log again as well: the abort path returned before write_log() was reached, so nothing was logged on failure.

@fiwswe maybe you can give this a try?
